### PR TITLE
Fix shared empty Dictionary/Array instances across resources (GH-107588)

### DIFF
--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -2304,6 +2304,15 @@ Variant ClassDB::class_get_default_property_value(const StringName &p_class, con
 
 	Variant var = default_values[p_class][p_property];
 
+	// Duplicate container types so callers don't share the same cached instance.
+	// Without this, all resources of the same class would share the same
+	// Dictionary/Array object in memory (GH-107588).
+	if (var.get_type() == Variant::DICTIONARY) {
+		var = Dictionary(var).duplicate();
+	} else if (var.get_type() == Variant::ARRAY) {
+		var = Array(var).duplicate();
+	}
+
 #ifdef DEBUG_ENABLED
 	// Some properties may have an instantiated Object as default value,
 	// (like Path2D's `curve` used to have), but that's not a good practice.

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -390,6 +390,14 @@ bool GDScript::get_property_default_value(const StringName &p_property, Variant 
 	HashMap<StringName, Variant>::ConstIterator E = member_default_values_cache.find(p_property);
 	if (E) {
 		r_value = E->value;
+		// Duplicate container types so callers don't share the same cached instance.
+		// Without this, all resources using this script would share the same
+		// Dictionary/Array object in memory (GH-107588).
+		if (r_value.get_type() == Variant::DICTIONARY) {
+			r_value = Dictionary(r_value).duplicate();
+		} else if (r_value.get_type() == Variant::ARRAY) {
+			r_value = Array(r_value).duplicate();
+		}
 		return true;
 	}
 
@@ -459,7 +467,15 @@ void GDScript::set_source_code(const String &p_code) {
 #ifdef TOOLS_ENABLED
 void GDScript::_update_exports_values(HashMap<StringName, Variant> &values, List<PropertyInfo> &propnames) {
 	for (const KeyValue<StringName, Variant> &E : member_default_values_cache) {
-		values[E.key] = E.value;
+		// Duplicate container types so each placeholder gets its own instance
+		// instead of sharing the same cached object (GH-107588).
+		if (E.value.get_type() == Variant::DICTIONARY) {
+			values[E.key] = Dictionary(E.value).duplicate();
+		} else if (E.value.get_type() == Variant::ARRAY) {
+			values[E.key] = Array(E.value).duplicate();
+		} else {
+			values[E.key] = E.value;
+		}
 	}
 
 	for (const PropertyInfo &E : members_cache) {

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -253,7 +253,14 @@ static bool _can_use_validate_call(const MethodBind *p_method, const Vector<GDSc
 
 GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &codegen, Error &r_error, const GDScriptParser::ExpressionNode *p_expression, bool p_root, bool p_initializer) {
 	if (p_expression->is_constant && !(p_expression->get_datatype().is_meta_type && p_expression->get_datatype().kind == GDScriptParser::DataType::CLASS)) {
-		return codegen.add_constant(p_expression->reduced_value);
+		// Don't treat Dictionary/Array literals as constants when used as member
+		// field initializers. Constants are shared across all instances via the
+		// function's constant pool, so every instance would reference the same
+		// object in memory. Instead, fall through to emit construction code that
+		// creates a fresh container for each instance (GH-107588).
+		if (!p_initializer || (p_expression->reduced_value.get_type() != Variant::DICTIONARY && p_expression->reduced_value.get_type() != Variant::ARRAY)) {
+			return codegen.add_constant(p_expression->reduced_value);
+		}
 	}
 
 	GDScriptCodeGenerator *gen = codegen.generator;
@@ -2912,7 +2919,15 @@ Error GDScriptCompiler::_prepare_compilation(GDScript *p_script, const GDScriptP
 
 #ifdef TOOLS_ENABLED
 				if (variable->initializer != nullptr && variable->initializer->is_constant) {
-					p_script->member_default_values[name] = variable->initializer->reduced_value;
+					Variant default_val = variable->initializer->reduced_value;
+					// Duplicate container types so the stored default is an independent
+					// mutable copy, not the shared read-only reduced value (GH-107588).
+					if (default_val.get_type() == Variant::DICTIONARY) {
+						default_val = Dictionary(default_val).duplicate();
+					} else if (default_val.get_type() == Variant::ARRAY) {
+						default_val = Array(default_val).duplicate();
+					}
+					p_script->member_default_values[name] = default_val;
 					GDScriptCompiler::convert_to_initializer_type(p_script->member_default_values[name], variable);
 				} else {
 					p_script->member_default_values.erase(name);

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -2640,6 +2640,14 @@ bool CSharpScript::get_property_default_value(const StringName &p_property, Vari
 	HashMap<StringName, Variant>::ConstIterator E = exported_members_defval_cache.find(p_property);
 	if (E) {
 		r_value = E->value;
+		// Duplicate container types so callers don't share the same cached instance.
+		// Without this, all resources using this script would share the same
+		// Dictionary/Array object in memory (GH-107588).
+		if (r_value.get_type() == Variant::DICTIONARY) {
+			r_value = Dictionary(r_value).duplicate();
+		} else if (r_value.get_type() == Variant::ARRAY) {
+			r_value = Array(r_value).duplicate();
+		}
 		return true;
 	}
 

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -2060,7 +2060,15 @@ void CSharpScript::_placeholder_erased(PlaceHolderScriptInstance *p_placeholder)
 #ifdef TOOLS_ENABLED
 void CSharpScript::_update_exports_values(HashMap<StringName, Variant> &values, List<PropertyInfo> &propnames) {
 	for (const KeyValue<StringName, Variant> &E : exported_members_defval_cache) {
-		values[E.key] = E.value;
+		// Duplicate container types so each placeholder gets its own instance
+		// instead of sharing the same cached object (GH-107588).
+		if (E.value.get_type() == Variant::DICTIONARY) {
+			values[E.key] = Dictionary(E.value).duplicate();
+		} else if (E.value.get_type() == Variant::ARRAY) {
+			values[E.key] = Array(E.value).duplicate();
+		} else {
+			values[E.key] = E.value;
+		}
 	}
 
 	for (const PropertyInfo &prop_info : exported_members_cache) {


### PR DESCRIPTION
Duplicate Dictionary and Array values when returning cached default property values, so each resource instance gets its own independent copy instead of sharing the same underlying object in memory.

can close issue no #1 

